### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Unique Features
 so, it is effective against GFW full text filtering.
 the page http://zh.wikipedia.org/zh/防火长城‎ is a typical example of full text filtering (the url does not trigger to RST)
 * for https, socket connect and full ssl handshake will be tried, if anything goes wrong (https certificate filtering for example), fallback to another proxy.
-* built-in support goagent as proxy, without starting an seperate goagent process
+* built-in support goagent as proxy, without starting an separate goagent process
 * resolve proxy info from TXT dns record
 
 Basic Usage

--- a/fqsocks/assets/visibility.core.js
+++ b/fqsocks/assets/visibility.core.js
@@ -205,7 +205,7 @@
         },
 
         // Return document’s property value with name with vendor prefix.
-        // If API is not support, it will retun `unsupported` value.
+        // If API is not support, it will return `unsupported` value.
         _prop: function (name, unsupported) {
             if ( !self.isSupported() ) {
                 return unsupported;

--- a/fqsocks/networking.py
+++ b/fqsocks/networking.py
@@ -27,7 +27,7 @@ def create_tcp_socket(server_ip, server_port, connect_timeout):
     sock = SPI['create_tcp_socket'](server_ip, server_port, connect_timeout)
     # set reuseaddr option to avoid 10048 socket error
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    # resize socket recv buffer 8K->32K to improve browser releated application performance
+    # resize socket recv buffer 8K->32K to improve browser related application performance
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 32*1024)
     # disable negal algorithm to send http request quickly.
     sock.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, True)


### PR DESCRIPTION
There are small typos in:
- README.md
- fqsocks/assets/visibility.core.js
- fqsocks/networking.py

Fixes:
- Should read `separate` rather than `seperate`.
- Should read `return` rather than `retun`.
- Should read `related` rather than `releated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md